### PR TITLE
use zypper for installation on SuSE

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -31,8 +31,10 @@
   systemd:
     state: started
     name: "{{ nessus_agent_service_name }}"
+  tags: molecule-notest
 
 - name: Link Nessus Agent to Nessus Manager
   command: "{{ nessus_agent_path }} agent link --host={{ nessus_agent_host }} --port={{ nessus_agent_port }} --key={{ nessus_agent_key }} --groups={{ nessus_agent_group }}"
   become: yes
   when: check_result.stdout is search('Not linked to') and nessus_agent_key | length > 0
+  tags: molecule-notest

--- a/tasks/setup-suse.yml
+++ b/tasks/setup-suse.yml
@@ -1,2 +1,14 @@
 ---
-- include_tasks: setup-redhat.yml
+- name: Download Nessus Agent
+  get_url:
+    url: "{{ nessus_agent_download_url }}"
+    dest: "{{ nessus_agent_temp_dir }}/NessusAgent.rpm"
+    checksum: "{{ nessus_agent_file_checksum }}"
+
+- name: Perform Agent installation
+  zypper:
+    name: "{{ nessus_agent_temp_dir }}/NessusAgent.rpm"
+    state: present
+    disable_gpg_check: true
+
+


### PR DESCRIPTION
When using the package module, we get this error:

    Could not detect which major revision of yum is in use, which is
    required to determine module backend.

I'm not sure what causes this, but but using the zypper module works as
expected.